### PR TITLE
Rails 5.1: Strings for `class_name` in relationships

### DIFF
--- a/app/models/spree/klarna_credit_payment.rb
+++ b/app/models/spree/klarna_credit_payment.rb
@@ -1,8 +1,8 @@
 module Spree
   class KlarnaCreditPayment < Spree::Base
     belongs_to :payment_method
-    belongs_to :user, class_name: Spree.user_class, foreign_key: 'user_id'
-    belongs_to :order, class_name: Spree::Order, foreign_key: 'spree_order_id'
+    belongs_to :user, class_name: Spree::UserClassHandle.new, foreign_key: 'user_id'
+    belongs_to :order, class_name: 'Spree::Order', foreign_key: 'spree_order_id'
     serialize :response_body, Hash
 
     scope :with_payment_profile, -> { where(false) }


### PR DESCRIPTION
> DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and
> will raise an ArgumentError in Rails 5.2. It eagerloads more classes than
> necessary and potentially creates circular dependencies. Please pass the class
> name as a string